### PR TITLE
Add fix for missing objectmanager in AssertPreferenceOf

### DIFF
--- a/Test/Integration/Traits/AssertPreferenceOf.php
+++ b/Test/Integration/Traits/AssertPreferenceOf.php
@@ -2,10 +2,13 @@
 
 namespace Yireo\IntegrationTestHelper\Test\Integration\Traits;
 
+use Magento\TestFramework\ObjectManager;
+
 trait AssertPreferenceOf
 {
     protected function assertPreferenceOf(string $expectedClass, string $injectableClass)
     {
-        $this->assertInstanceOf($expectedClass, $this->objectManager->get($injectableClass));
+        $objectManager = ObjectManager::getInstance();
+        $this->assertInstanceOf($expectedClass, $objectManager->get($injectableClass));
     }
 }


### PR DESCRIPTION
When I want to use the "AssertPreferenceOf" trait, I get the following error.

```
Warning: Undefined property: MaxServ\Mate\Test\Integration\ModuleTest::$objectManager in /var/www/html/magento2/vendor/yireo/magento2-integration-test-helper/Test/Integration/Traits/AssertPreferenceOf.php: 9
```

This can be solved by loading and initialization of the object manager.